### PR TITLE
Allow gitpod as this template is gitpod ready

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,6 +42,9 @@ module.exports = {
     },
     devServer: {
         historyApiFallback: true,
+        allowedHosts: [
+            '.gitpod.id',
+        ],
         static: {
             directory: path.resolve(__dirname, "./dist"),
         },


### PR DESCRIPTION
This is just a small fix, not required if intend to use this template on a local machine
I just want to be explicit here so I won't put `'all'` as `allowedHosts` object