### PR TITLE
build: Exclude node_modules from .json test rule

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,8 @@ module.exports = {
             },
             {
                 test: /\.json/,
-                type: "asset/resource"
+                type: "asset/resource",
+                exclude: /node_modules/,
             }
         ],
     },


### PR DESCRIPTION
I got into some issues when I was integrating `near-api-js` in my project (which I forked from this repo).
I have created a Q&A on StackOverflow about the details https://stackoverflow.com/q/72377132/1471485